### PR TITLE
Fix PolicyDocument

### DIFF
--- a/lib/kumogata/template/iam.rb
+++ b/lib/kumogata/template/iam.rb
@@ -55,7 +55,10 @@ def _iam_policies(name, args)
   policies = args[name.to_sym] || []
   policies.each_with_index do |v, i|
     array << _{
-      PolicyDocument _iam_policy_document("document", v)
+      PolicyDocument do
+        Version "2012-10-17"
+        Statement _iam_policy_document("document", v)
+      end
       PolicyName v[:name] || _resource_name("policy", i)
     }
   end

--- a/test/iam_test.rb
+++ b/test/iam_test.rb
@@ -62,17 +62,20 @@ Policies _iam_policies "test", test: [ { document: [ { service: "s3" } ] } ]
 {
   "Policies": [
     {
-      "PolicyDocument": [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "s3:*"
-          ],
-          "Resource": [
-            "*"
-          ]
-        }
-      ],
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "s3:*"
+            ],
+            "Resource": [
+              "*"
+            ]
+          }
+        ]
+      },
       "PolicyName": "Policy0"
     }
   ]


### PR DESCRIPTION
Error Msg: Value of property PolicyDocument must be an object
ref: http://docs.aws.amazon.com/ja_jp/IAM/latest/UserGuide/access_policies.html