### PR TITLE
fix: prevent mutating user_data argument

### DIFF
--- a/lib/kumogata/template/ec2.rb
+++ b/lib/kumogata/template/ec2.rb
@@ -234,7 +234,7 @@ cat <<'EOF' >> /etc/ecs/ecs.config
 ECS_CLUSTER=#{_name("ecs", args)}
 EOF
 EOS
-      user_data = user_data.insert(0, ecs_user_data)
+      user_data = [ecs_user_data] + user_data
     end
     _base64_shell(user_data)
   end

--- a/test/ec2_test.rb
+++ b/test/ec2_test.rb
@@ -431,4 +431,42 @@ Test _ec2_spot_fleet_launches({ block_devices: [ { ref_size: "test" } ], iam: "t
     EOS
     assert_equal exp_template.chomp, act_template
   end
+
+  def test_ec2_user_data_ecs
+    template = <<-EOS
+user_data = ["X"]
+Test1 _ec2_user_data(user_data: user_data, ecs: true)
+Test2 _ec2_user_data(user_data: user_data, ecs: true)
+    EOS
+    act_template = run_client_as_json(template)
+    exp_template = <<-EOS
+{
+  "Test1": {
+    "Fn::Base64": {
+      "Fn::Join": [
+        "\\n",
+        [
+          "#!/bin/bash",
+          "cat <<'EOF' >> /etc/ecs/ecs.config\\nECS_CLUSTER=true\\nEOF\\n",
+          "X"
+        ]
+      ]
+    }
+  },
+  "Test2": {
+    "Fn::Base64": {
+      "Fn::Join": [
+        "\\n",
+        [
+          "#!/bin/bash",
+          "cat <<'EOF' >> /etc/ecs/ecs.config\\nECS_CLUSTER=true\\nEOF\\n",
+          "X"
+        ]
+      ]
+    }
+  }
+}
+    EOS
+    assert_equal exp_template.chomp, act_template
+  end
 end


### PR DESCRIPTION
Calling `_ecs_user_data(user_data: user_data, ecs: true)` multiple times bring unexpected results because user_data is changed in `_ec2_user_data`.

```
user_data = ["X"]
Test1 _ec2_user_data(user_data: user_data, ecs: true)
Test2 _ec2_user_data(user_data: user_data, ecs: true)
```

```
Test1:
...
  [
    "#!/bin/bash",
    "cat <<'EOF' >> /etc/ecs/ecs.config\nECS_CLUSTER=true\nEOF\n",
    "#!/bin/bash",
    "cat <<'EOF' >> /etc/ecs/ecs.config\nECS_CLUSTER=true\nEOF\n",
    "X"
  ]
...
Test2:
...
  [
    "#!/bin/bash",
    "cat <<'EOF' >> /etc/ecs/ecs.config\nECS_CLUSTER=true\nEOF\n",
    "#!/bin/bash",
    "cat <<'EOF' >> /etc/ecs/ecs.config\nECS_CLUSTER=true\nEOF\n",
    "X"
  ]
```

And this changes enable to freeze user_data.